### PR TITLE
Updating instructions to Allow Azure Services to connect to Azure SQL

### DIFF
--- a/Instructions/Labs/Module_6_Lab.md
+++ b/Instructions/Labs/Module_6_Lab.md
@@ -91,7 +91,7 @@ The main tasks for this exercise are as follows:
     | Setting | Value | 
     | --- | --- |
     | Connectivity method | **Public endpoint** |    
-    | Allow Azure services and resources to access this server | **No** |
+    | Allow Azure services and resources to access this server | **Yes** |
     | Add current client IP address | **Yes** |
 
 1. Select **Next: Additional settings >**. 


### PR DESCRIPTION
On Exercise 1, Task 1, Step 8 You need to select Yes under Networking - Allow Azure services and resources to access this server.
Otherwise the connection will fail.

# Module: 6
## Lab/Demo: Lab

Fixes # .

Changes proposed in this pull request:

- While creating the Azure SQL instances under Networking - Allow Azure services and resources to access this server you need to select Yes, otherwise the connection will fail
- Currently the instructions have this item as No
- On the previous step the option is no longer available there, however the instructions still reflect this old interface