### PR TITLE
Add -SkipAssignment option to New-AzADServicePrincipal command.

### DIFF
--- a/Instructions/Labs/Module_13_Lab_a.md
+++ b/Instructions/Labs/Module_13_Lab_a.md
@@ -1,3 +1,4 @@
+active
 ---
 lab:
     title: '13: Implement Azure Logic Apps integration with Azure Event Grid'
@@ -138,7 +139,7 @@ The main tasks for this exercise are as follows:
 1. From the Cloud Shell pane, run the following to create a new Azure AD service principal associated with the application you created in the previous step:
 
    ```powershell
-   New-AzADServicePrincipal -ApplicationId $az30304aadapp.ApplicationId.Guid
+   New-AzADServicePrincipal -ApplicationId $az30304aadapp.ApplicationId.Guid -SkipAssignment
    ```
 
 1. In the output of the **New-AzADServicePrincipal** command, note the value of the **ApplicationId** property. You will need it later in this exercise.


### PR DESCRIPTION
Lab 13.
The option -SkipAssignement in the command allows the command to create the service principal without assigns any role to the new service principal.
If you don't use that options, the command assigns the contributor role for all the subscription to the new service principal (as in documentation https://docs.microsoft.com/en-us/powershell/module/az.resources/new-azadserviceprincipal?view=azps-5.0.0) and the next assignment step is not valid