### PR TITLE
Clean up extra text in markdown

### DIFF
--- a/Instructions/Labs/Module_13_Lab_a.md
+++ b/Instructions/Labs/Module_13_Lab_a.md
@@ -1,4 +1,3 @@
-active
 ---
 lab:
     title: '13: Implement Azure Logic Apps integration with Azure Event Grid'


### PR DESCRIPTION
Removed the word "active" from the beginning of the markdown, which was causing a problem in GitHub Pages.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-