### PR TITLE
Updated instructions to match Portal

### DIFF
--- a/Instructions/Labs/Module_6_Lab.md
+++ b/Instructions/Labs/Module_6_Lab.md
@@ -78,7 +78,6 @@ The main tasks for this exercise are as follows:
     | Server admin login | **sqladmin** |
     | Password | **Pa55w.rd1234** |
     | Location | the name of an Azure region where you can provision SQL databases |
-    | Allow Azure services to access server | ensure that the checkbox is cleared |
 
 1. Next to the **Compute + storage** label, select the **Configure database** link.
 


### PR DESCRIPTION
Removed " Allow Azure services to access server" "ensure that the checkbox is cleared" - in the Portal this is now in the Networking tab, as per the later step in these instructions.

# Module: 06
## Lab/Demo: 06

Fixes # .

Changes proposed in this pull request:

-
-
-