### PR TITLE
Update Module_6_Lab.md

### DIFF
--- a/Instructions/Labs/Module_6_Lab.md
+++ b/Instructions/Labs/Module_6_Lab.md
@@ -303,7 +303,7 @@ The main tasks for this exercise are as follows:
 1. From the Cloud Shell pane, run the following to list the resource group you created in this exercise:
 
    ```sh
-   az group list --query "[?starts_with(name,'az30303')]".name --output tsv
+   az group list --query "[?starts_with(name,'az30303')].name" --output tsv
    ```
 
     > **Note**: Verify that the output contains only the resource group you created in this lab. This group will be deleted in this task.
@@ -311,7 +311,7 @@ The main tasks for this exercise are as follows:
 1. From the Cloud Shell pane, run the following to delete the resource group you created in this lab
 
    ```sh
-   az group list --query "[?starts_with(name,'az30303')]".name --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
+   az group list --query "[?starts_with(name,'az30303')].name" --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
    ```
 
 1. From the Cloud Shell pane, run the following to remove the folder named **az30303a1**:


### PR DESCRIPTION
The instructions to remove the Azure resources are wrong. Should be az group list --query "[?starts_with(name,'az30303')].name" instead of az group list --query "[?starts_with(name,'az30303')]".name for both commands.
I corrected that!

# Module: 06
## Lab: Implementing Azure SQL Database-Based Applications

Fixes # .

Changes proposed in this pull request:

The instructions to remove the resources are wrong.
Should be: az group list --query "[?starts_with(name,'az30303')]".name
Instead of az group list --query "[?starts_with(name,'az30303')]".name for both commands
If you run as it is, it will fail