### PR TITLE
Modifications to instructions to match changes in portal

### DIFF
--- a/Instructions/Labs/Module_13_Lab_a.md
+++ b/Instructions/Labs/Module_13_Lab_a.md
@@ -165,7 +165,7 @@ The main tasks for this exercise are as follows:
     | Setting | Value | 
     | --- | --- |
     | Role | **Reader** |
-    | Assign access to | **Azure AD user, group, or service principal** |
+    | Assign access to | **User, group, or service principal** |
     | Select | **az30304aadsp** |
 
 
@@ -184,7 +184,7 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Create an Azure logic app
 
-1. In the Azure portal, search for and select **Logic App** and, on the **Logic Apps** blade, select **+ Add**.
+1. In the Azure portal, search for and select **Logic App** and, on the **Logic Apps** blade, select **+ Add** the select **Consumption**.
 
 1. On the **Basics** tab of the **Logic App** blade, specify the following settings (leave others with their default values):
 
@@ -223,7 +223,7 @@ The main tasks for this exercise are as follows:
 
     | Setting | Value | 
     | --- | --- |
-    | Subscription | the value of subscription **Id** property you identified earlier in this exercise |
+    | Subscription | Choose your subscription from the drop-down list |
     | Resource Type | **Microsoft.Resources.resourceGroups** |
     | Resource Name | **az30304a-labRG** |
     | Event Type Item - 1 | **Microsoft.Resources.ResourceWriteSuccess** |
@@ -301,7 +301,7 @@ The main tasks for this exercise are as follows:
 
 #### Task 1: Configure event subscription
 
-1. In the Azure portal, navigate to the **az30304b-logicapp1** blade, in the **Summary** section, select **See trigger history**. 
+1. In the Azure portal, navigate to the **az30304b-logicapp1** blade, in the **Summary** section, select **Trigger history**. 
 
 1. On the **When_a_resource_event_occurs** blade, copy the value of the **Callback url [POST]** text box.
 

--- a/Instructions/Labs/Module_3_Lab.md
+++ b/Instructions/Labs/Module_3_Lab.md
@@ -402,7 +402,7 @@ The main tasks for this exercise are as follows:
 
 1. In the Virtual Machine Connection window to the virtual appliance, sign in by using the newly set password.
 
-1. Within the Remote Desktop session to the virtual appliance, start Windows PowerShell and run the following to identify its IP address.
+1. Within the Virtual Machine Connection window to the virtual appliance, start Windows PowerShell and run the following to identify its IP address.
 
    ```powershell
    (Get-NetIPAddress).IPAddress
@@ -423,7 +423,7 @@ The main tasks for this exercise are as follows:
 
 1. Within the Microsoft Edge window, on the **Appliance Configuration Manager** page, select the **I agree** button, wait for the prerequisites to be successfully verified, and select **Continue**. 
 
-1. Within the Microsoft Edge window, on the **Appliance Configuration Manager** page, in the **Register with Azure Migrate** section, in the **Provide Azure Migrate project key** text box, paste the key you copied into Notepad earlier in this exercise, select **Login**, accept the default code displayed in the **Enter code** pane in the browser page, sign in by providing credentials of a user account with the Owner role in the subscription you are using in this lab and close the browser page. 
+1. Within the Microsoft Edge window, on the **Appliance Configuration Manager** page, in the **Register with Azure Migrate** section, in the **Provide Azure Migrate project key** text box, paste the key you copied into Notepad earlier in this exercise, select **Login**, accept the default code displayed and copy it to the clipboard, then select **Copy code and login** then in the **Enter code** pane in the browser page paste in the code you copied to the clipboard and select **Next**, sign in by providing credentials of a user account with the Owner role in the subscription you are using in this lab and close the browser page. 
 
 1. Within the Microsoft Edge window, on the **Appliance Configuration Manager** page, verify that registration was successful and select **Continue**. 
 
@@ -448,7 +448,7 @@ The main tasks for this exercise are as follows:
 
    >**Note**: You might need to refresh the page again. 
 
-1. On the **Assessment properties** blade select **Edit** (the pencil icon), specify the following settings (leave others with their default values) and select **Save**:
+1. On the **Assessment properties** blade select **Edit**, specify the following settings (leave others with their default values) and select **Save**:
 
     | Setting | Value | 
     | --- | --- |

--- a/Instructions/Labs/Module_3_Lab.md
+++ b/Instructions/Labs/Module_3_Lab.md
@@ -448,7 +448,7 @@ The main tasks for this exercise are as follows:
 
    >**Note**: You might need to refresh the page again. 
 
-1. On the **Assessment properties** blade, specify the following settings (leave others with their default values) and select **Save**:
+1. On the **Assessment properties** blade select **Edit** (the pencil icon), specify the following settings (leave others with their default values) and select **Save**:
 
     | Setting | Value | 
     | --- | --- |

--- a/Instructions/Labs/Module_3_Lab.md
+++ b/Instructions/Labs/Module_3_Lab.md
@@ -274,7 +274,7 @@ The main tasks for this exercise are as follows:
 
 #### Task 3: Implement the target Azure environment
 
-1. In the Azure portal, search for and select **Virtual networks** and, on the **Virtual networks** blade, select **+ Add**.
+1. In the Azure portal, search for and select **Virtual networks** and, on the **Virtual networks** blade, select **+ New**.
 
 1. On the **Basics** tab of the **Create virtual network** blade, specify the following settings (leave others with their default values) and select **Next: IP Addresses**:
 
@@ -298,7 +298,7 @@ The main tasks for this exercise are as follows:
 
 1. On the **Review + create** tab of the **Create virtual network** blade, select **Create**.
 
-1. In the Azure portal, search for and select **Virtual networks** and, on the **Virtual networks** blade, select **+ Add**.
+1. In the Azure portal, search for and select **Virtual networks** and, on the **Virtual networks** blade, select **+ New**.
 
 1. On the **Basics** tab of the **Create virtual network** blade, specify the following settings (leave others with their default values) and select **Next: IP Addresses**:
 
@@ -322,7 +322,7 @@ The main tasks for this exercise are as follows:
 
 1. On the **Review + create** tab of the **Create virtual network** blade, select **Create**.
 
-1. In the Azure portal, search for and select **Storage accounts** and, on the **Storage accounts** blade, select **+ Add**.
+1. In the Azure portal, search for and select **Storage accounts** and, on the **Storage accounts** blade, select **+ New**.
 
 1. On the **Basics** tab of the **Create storage account** blade, specify the following settings (leave others with their default values):
 
@@ -378,7 +378,7 @@ The main tasks for this exercise are as follows:
 
 1. On the **Select Virtual Machine** page of the **Import Virtual Machine** wizard, select **Next >**:
 
-1. On the **Choose Import Type** page of the **Import Virtual Machine** wizard, select **Register the virtual machine (use the existing unique ID)** and select **Next >**.
+1. On the **Choose Import Type** page of the **Import Virtual Machine** wizard, select **Register the virtual machine in place (use the existing unique ID)** and select **Next >**.
 
 1. On the **Configure Processor** page of the **Import Virtual Machine** wizard, set **Number of virtual processors** to **4**, and select **Next >**.
 
@@ -439,14 +439,14 @@ The main tasks for this exercise are as follows:
 
 1. Within the Microsoft Edge window, on the **Appliance Configuration Manager** page, in the **Provide Hyper-V host/cluster details** section, select **Start discovery**. 
 
-   >**Note**: In general, it might take about 1.5 minutes per host for metadata of discovered servers to appear in the Azure portal.
+   >**Note**: In general, it might take about 15 minutes per host for metadata of discovered servers to appear in the Azure portal.
 
 
 #### Task 2: Configure, run, and view an assessment
 
 1. Within the Remote Desktop session to **az30308a-hv-vm**, in the Internet Explorer window displaying the Azure portal, navigate back to the **Azure Migrate | Servers** blade, select **Refresh**, and, in the **Azure Migrate: Server Assessment** tile, select **Assess**.
 
-   >**Note**: You might refresh the page again. 
+   >**Note**: You might need to refresh the page again. 
 
 1. On the **Assessment properties** blade, specify the following settings (leave others with their default values) and select **Save**:
 
@@ -511,7 +511,7 @@ The main tasks for this exercise are as follows:
 
     >**Note**: This step automatically triggers provisioning of an Azure Site Recovery vault.
 
-1. On the **Discover machines** blade, in step **1. Prepare Hyper-V host servers**, select the first **Download** link in order to download the Hyper-V replication provider software installer.
+1. On the **Discover machines** blade, in step **1. Prepare Hyper-V host servers**, select the first **Download** link (not the Download button), in order to download the Hyper-V replication provider software installer.
 
 1. When prompted, launch **AzureSiteRecoveryProvider.exe**. This will start the **Azure Site Recovery Provider Setup (Hyper-V server)** wizard.
 

--- a/Instructions/Labs/Module_3_Lab.md
+++ b/Instructions/Labs/Module_3_Lab.md
@@ -592,11 +592,11 @@ The main tasks for this exercise are as follows:
 
 1. On the **Azure Migrate: Server Migration | Replicating machines** blade, select the entry representing the **az30308a-vm1** virtual machine.
 
-1. On the **az30308a-vm1** replicating machines blade, select **Clean up test migration*.
+1. On the **az30308a-vm1** replicating machines blade, select **Clean up test migration**.
 
 1. On the **Test migrate cleanup** blade, select the checkbox **Testing is complete. Delete test virtual machine** and select **Cleanup Test**.
 
-1. Once the test failover cleanup job completes, refresh the browser page displaying the **az30308a-vm1** replicating machines blade and note that the **Migrate** icon in the toolbar became automatically available.
+1. Once the test failover cleanup job completes, refresh the browser page displaying the **az30308a-vm1** replicating machines blade and note that the **Migrate** icon in the toolbar automatically became available.
 
 1. On the **az30308a-vm1** replicating machines blade, select the **Migrate** link. 
 
@@ -604,7 +604,7 @@ The main tasks for this exercise are as follows:
 
 1. To monitor the status of migration, navigate back to the **Azure Migrate | Servers** blade, in the **Azure Migrate: Server Migration** tile, select the **Replicating servers** entry and, on the **Azure Migrate: Server Migration | Replicating machines**, examine the **Status** column in the list of the replicating machines. Verify that the status displayed the **Planned failover finished** status.
 
-   >**Note**: Migration is supposed to be a non-reversible action.
+   >**Note**: Migration is supposed to be a non-reversible action. If you want to see the completed information, navigate back to the Azure Migrate | Servers blade, refresh the page and verify that Migrated Servers in the Azure Migrate: Server Migration tile has a value of 1.
 
 
 #### Task 4: Remove Azure resources deployed in the lab

--- a/Instructions/Labs/Module_6_Lab.md
+++ b/Instructions/Labs/Module_6_Lab.md
@@ -60,7 +60,7 @@ The main tasks for this exercise are as follows:
 
 1. From your lab computer, start a web browser, navigate to the [Azure portal](https://portal.azure.com), and sign in by providing credentials of a user account with the Owner role in the subscription you will be using in this lab.
 
-1. In the Azure portal, search for and select **SQL database** and, on the **SQL databases** blade, select **+ Add**.
+1. In the Azure portal, search for and select **SQL database** and, on the **SQL databases** blade, select **+ New**.
 
 1. On the **Basics** tab of the **Create SQL Database** blade, specify the following settings (leave others with their default values):
 


### PR DESCRIPTION

[AZ304_Change_log_March2021_BillWood.docx](https://github.com/MicrosoftLearning/AZ-304-Microsoft-Azure-Architect-Design/files/6160426/AZ304_Change_log_March2021_BillWood.docx)
# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

•	Module 3 - Lab 1 - Exercise 1:  
o	The Azure portal now uses the New option for creating a virtual network, and storage       accounts, it is no longer Add.
o	The import virtual machine registration option is register virtual machine in place.
o	In the Appliance Configuration Manager, the registration requires the copying of the code so that it may be pasted/entered in the subsequent screen.
o	Discovery of servers for migration can take up to 15 minutes per server.
o	You must select the Download hyperlink, not the Download button to start the Azure Site Recovery Provider setup program.


•	Module 6 - Lab 1 - Exercise 1: 
o	The option for creating a new Azure SQL Database is now +New, no longer +Add.

 
•	Module 13 - Lab 1 - Exercise 1 
o	The option for adding a role assignment Assign access to is User, group, or service principal, the prefix Azure AD is not in the choice list.

•	Module 13 - Lab 1 - Exercise 2 
o	You must choose the type of logic app, Consumption should be the one used for this lab.

•	Module 13 - Lab 1 - Exercise 3 
o	Trigger history is just listed as Trigger history in the summary screen of the Logic App, it is not See trigger history

-
-