### PR TITLE
Changes to options in portal

### DIFF
--- a/Instructions/Labs/Module_4_Lab.md
+++ b/Instructions/Labs/Module_4_Lab.md
@@ -207,11 +207,11 @@ The main tasks for this exercise are as follows:
 
 1. On the **Azure Active Directory Premium P2 \| Licensed users** blade, select **+ Assign**. 
 
-1. On the **Assign license** blade, select **Users**, and on the **Users** blade, select both your account and the **az30410-aaduser1** user account and click **Select** for each.
+1. On the **Assign license** blade, select **Add users and groups**, and on the **Add users and groups** blade, select both your account and the **az30410-aaduser1** user account and click **Select** for each.
 
 1. Back on the **Assign license** blade, select **Assignment options**, review the options listed on the **License options** blade, and select **OK**.
 
-1. On the **Assign license** blade, select **Assign**. 
+1. On the **Assign license** blade, select **Review and Assign** the on the **Assign** page, select **Assign**. 
 
 
 ### Exercise 2: Integrate an AD DS forest with an Azure AD tenant

--- a/Instructions/Labs/Module_6_Lab.md
+++ b/Instructions/Labs/Module_6_Lab.md
@@ -60,7 +60,7 @@ The main tasks for this exercise are as follows:
 
 1. From your lab computer, start a web browser, navigate to the [Azure portal](https://portal.azure.com), and sign in by providing credentials of a user account with the Owner role in the subscription you will be using in this lab.
 
-1. In the Azure portal, search for and select **SQL database** and, on the **SQL databases** blade, select **+ Add**.
+1. In the Azure portal, search for and select **SQL database** and, on the **SQL databases** blade, select **+ Create**.
 
 1. On the **Basics** tab of the **Create SQL Database** blade, specify the following settings (leave others with their default values):
 


### PR DESCRIPTION
•	Module 3 - Lab 1 - Exercise 1:  
o	When creating storage accounts, the Account kind is no longer an option. The wizard defaults to General Purpose V2.
o	The assessment properties option is Reserved capacity not reserved instances, and the VM sizing option is criteria.
o	In the Replication configuration blade, the subsequent page is no longer listed with the Next:  button, it just says Next.

•	Module 4 - Lab 1 - Exercise 1: 
o	The process for assigning the AAD Premium P2 license to users has different option names now. 

•	Module 6 - Lab 1 - Exercise 1: 
o	The option for creating a new Azure SQL Database is now + Create, no longer + Add.
[AZ304_Change_log_May2021_BillWood.docx](https://github.com/MicrosoftLearning/AZ-304-Microsoft-Azure-Architect-Design/files/6497732/AZ304_Change_log_May2021_BillWood.docx)

-