### PR TITLE
Update Module_3_Lab.md

### DIFF
--- a/Instructions/Labs/Module_3_Lab.md
+++ b/Instructions/Labs/Module_3_Lab.md
@@ -72,7 +72,7 @@ The main tasks for this exercise are as follows:
 
 1. In the toolbar of the Cloud Shell pane, select the **Upload/Download files** icon, in the drop-down menu select **Upload**, and upload the file **\\\\AZ303\\AllFiles\Labs\\08\\azuredeploy30308suba.json** into the Cloud Shell home directory.
 
-1. From the Cloud Shell, run the following command to set a variable named location with an Azure Region near you (replace the '\<Azure region\>' placeholder with the name of the Azure region that is available for deployment of Azure VMs in your subscription and which is closest to the location of your lab computer, for example 'eastus'):
+1. From the Cloud Shell, run the following command to set a variable named location with an Azure Region near you (replace the '&lt;Azure region&gt;' placeholder with the name of the Azure region that is available for deployment of Azure VMs in your subscription and which is closest to the location of your lab computer, for example 'eastus'):
 
    ```powershell
    $location = '<Azure region>'


### PR DESCRIPTION
Even escaped, the '<Azure Region>' may not display as expected in certain markdown engines. I recommend replacing the escaped characters with &lt; and &gt; instead.

# Module: 3
#exercise 0
##Step 5

Fixes # .

'<Azure Region>' not displaying correctly in certain markdown engines.

Changes proposed in this pull request:

- replace \< and \> with &lt; and &gt; respectively